### PR TITLE
web/manifest: Adding display: standalone.

### DIFF
--- a/web/manifest.json
+++ b/web/manifest.json
@@ -32,5 +32,6 @@
         "type": "image/png",
         "density": 1
       }],
-  "start_url": "index.html"
+  "start_url": "index.html",
+  "display": "standalone"
 }


### PR DESCRIPTION
Required for Chrome's app banner to trigger.
