### PR TITLE
Fix some broken apps.

### DIFF
--- a/ios_and_play/manifest.json
+++ b/ios_and_play/manifest.json
@@ -1,10 +1,10 @@
 {
   "prefer_related_applications": true,
   "related_applications": [{
-        "platform": "play",
-        "id": "com.sbg.crappybird"
-      },{
         "platform": "ios",
         "id": "basdfasdf"
+      },{
+        "platform": "play",
+        "id": "com.sbg.crappybird"
       }]
 }

--- a/ios_and_web/sw.js
+++ b/ios_and_web/sw.js
@@ -17,4 +17,6 @@ self.addEventListener('install', function(event) {
   );
 });
 
-
+// Required to be installable.
+self.addEventListener('fetch', function(event) {
+});

--- a/play_and_web/sw.js
+++ b/play_and_web/sw.js
@@ -17,4 +17,6 @@ self.addEventListener('install', function(event) {
   );
 });
 
-
+// Required to be installable.
+self.addEventListener('fetch', function(event) {
+});

--- a/web_and_ios/manifest.json
+++ b/web_and_ios/manifest.json
@@ -11,5 +11,6 @@
         "platform": "ios",
         "id": "blahblahblah"
       }],
-  "start_url": "index.html"
+  "start_url": "index.html",
+  "display": "standalone"
 }

--- a/web_and_play/index.js
+++ b/web_and_play/index.js
@@ -26,18 +26,16 @@ function logMessage(message, isError) {
 }
 
 window.addEventListener("beforeinstallprompt", function(e) {
-  document.open();
-  document.write('Got beforeinstallprompt!!!<br>');
-  document.write('platforms: ');
-  document.write(e.platforms);
-  document.write('<br>Should I cancel it? Hmmmm .... ');
+  logMessage('Got beforeinstallprompt!!!<br>');
+  logMessage('platforms: ');
+  logMessage(e.platforms);
+  logMessage('<br>Should I cancel it? Hmmmm .... ');
   if (Math.random() > 0.5) {
-    document.write('Yeah why not. Cancelled!');
+    logMessage('Yeah why not. Cancelled!');
     e.preventDefault();
   } else {
-    document.write("No, let's see the banner");
+    logMessage("No, let's see the banner");
   }
-  document.close();
 });
 
 window.addEventListener('load', async e => {

--- a/web_and_play/manifest.json
+++ b/web_and_play/manifest.json
@@ -14,5 +14,6 @@
         "platform": "play",
         "id": "io.github.benfredwells.killermarmot"
       }],
-  "start_url": "index.html"
+  "start_url": "index.html",
+  "display": "standalone"
 }

--- a/web_no_meta_viewport/index.js
+++ b/web_no_meta_viewport/index.js
@@ -18,7 +18,7 @@ window.addEventListener("beforeinstallprompt", function(e) {
     setTimeout(function() {
       isTooSoon = false;
       console.log("Dispatching event");
-      window.dispatchEvent(e); // Shows prompt
+      e.prompt() // Shows prompt
       console.log(e);
     }, 5000);
   }

--- a/web_no_meta_viewport/manifest.json
+++ b/web_no_meta_viewport/manifest.json
@@ -8,29 +8,30 @@
         "density": 1
       }, {
         "src": "../marmot_48.png",
-        "sizes": "48",
+        "sizes": "48x48",
         "type": "image/png",
         "density": 1
       }, {
         "src": "../marmot_96.png",
-        "sizes": "96",
+        "sizes": "96x96",
         "type": "image/png",
         "density": 1
       }, {
         "src": "../marmot_128.png",
-        "sizes": "128",
+        "sizes": "128x128",
         "type": "image/png",
         "density": 1
       }, {
         "src": "../marmot_200.png",
-        "sizes": "200",
+        "sizes": "200x200",
         "type": "image/png",
         "density": 1
       }, {
         "src": "../marmot_480.png",
-        "sizes": "480",
+        "sizes": "480x480",
         "type": "image/png",
         "density": 1
       }],
-  "start_url": "index.html"
+  "start_url": "index.html",
+  "display": "standalone"
 }


### PR DESCRIPTION
- ios_and_play: Swap order in manifest so this tests what it claims to
  test.
- ios_and_web, play_and_web: Added empty fetch handler (like other SWs).
- web_and_ios, web_and_play, web_no_meta_viewport: Added display: standalone.
- web_and_play: Use new logging mechanism to avoid replacing the entire
  page when beforeinstallprompt is caught.
- web_no_meta_viewport: Use e.prompt() instead of
  window.dispatchEvent(e). Not sure if that was ever supposed to work, but
  it doesn't anymore.
- web_no_meta_viewport: Fixed icon sizes ("96x96" instead of "96").