### PR TITLE
Update all apps' JavaScript code to be the same.

### DIFF
--- a/ios_and_web/index.html
+++ b/ios_and_web/index.html
@@ -7,5 +7,6 @@
 <body>
   <h1>Marmots are the best.</h1>
   <p>Site which is a valid web app, but has a preferred iOS app in its manifest. v2.</p>
+  <div id="logs"></div>
 </body>
 </html>

--- a/ios_and_web/index.js
+++ b/ios_and_web/index.js
@@ -1,43 +1,98 @@
 if ('serviceWorker' in navigator) {
-  navigator.serviceWorker.register('sw.js').then(function(registration) {
+  navigator.serviceWorker.register('sw.js').then(registration => {
     // Registration was successful
     console.log('ServiceWorker registration successful with scope: ',    registration.scope);
-  }).catch(function(err) {
+  }).catch(err => {
     // registration failed :(
     console.log('ServiceWorker registration failed: ', err);
   });
 }
 
-e_copy = null;
-
-window.addEventListener("beforeinstallprompt", function(e) {
-  e_copy = e;
-  document.open();
-  document.write('Got beforeinstallprompt!!!<br>');
-  document.write('platforms: ');
-  document.write(e.platforms);
-  document.write('<br>Should I cancel it? Hmmmm .... ');
-  if (Math.random() > 0.5) {
-    document.write('Yeah why not. Cancelled!');
-    e.preventDefault();
-  } else {
-    document.write("No, let's see the banner");
-    document.write("<br>The promise is: " + e_copy.userChoice);
-    window.setTimeout(onTimer, 1000);
-  }
-  document.close();
-});
-
-function onTimer() {
-  if (!e_copy) {
-    document.write("No event????");
-    return;
-  }
-  document.write("Timer time!<br>");
-  e_copy.userChoice.then(function(result) {
-    document.write("platform is: '" + result.platform + "'<br>");
-    document.write("outcome is: '" + result.outcome + "'");
-  }, function() {
-    document.write('Boo! an error');
+// Creates a promise that resolves after a given number of milliseconds.
+function sleep(milliseconds) {
+  return new Promise((resolve, reject) => {
+      window.setTimeout(resolve, milliseconds);
   });
 }
+
+// Logs a message to the page, and console.
+function logMessage(message, isError) {
+  // Insert a paragraph into the page.
+  var logsDiv = document.querySelector('#logs');
+  var p = document.createElement('p');
+  logsDiv.appendChild(p);
+  p.appendChild(document.createTextNode(message));
+  if (isError)
+    p.style.color = 'red';
+
+  // Also log to the console.
+  if (isError)
+    console.error(message);
+  else
+    console.log(message);
+}
+
+// Logs a clickable link to the page. Returns a promise that resolves when the
+// user clicks the link.
+function logClickableLink(text) {
+  // Insert a paragraph into the page.
+  var logsDiv = document.querySelector('#logs');
+  var p = document.createElement('p');
+  logsDiv.appendChild(p);
+  var a = document.createElement('a');
+  p.appendChild(a);
+  a.setAttribute('href', '');
+  a.appendChild(document.createTextNode(text));
+
+  return new Promise((resolve, reject) => {
+    a.addEventListener('click', e => {
+      e.preventDefault();
+      resolve()
+    });
+  });
+}
+
+async function logUserChoice(e) {
+  logMessage('userChoice is: ' + e.userChoice);
+  await sleep(1000);
+  if (!e) {
+    logMessage('No event????', true);
+    return;
+  }
+
+  logMessage('Timer time!');
+  try {
+    let {platform, outcome} = await e.userChoice;
+    logMessage('platform is: \'' + platform + '\'');
+    logMessage('outcome is: \'' + outcome + '\'');
+  } catch (e) {
+    logMessage('Boo! an error', true);
+  }
+}
+
+window.addEventListener('beforeinstallprompt', async e => {
+  logMessage('Got beforeinstallprompt!!!');
+  logMessage('platforms: ' + e.platforms);
+  logMessage('Should I cancel it? Hmmmm .... ');
+
+  if (Math.random() > 0.5) {
+    logMessage('Yeah why not. Cancelled!');
+    e.preventDefault();
+    await logClickableLink('Show the prompt after all.');
+    try {
+      await e.prompt();
+      logMessage('prompt() resolved');
+    } catch (ex) {
+      logMessage('prompt() rejected with ' + ex, true);
+    }
+    logUserChoice(e);
+    return;
+  }
+
+  logMessage('No, let\'s see the banner');
+  logUserChoice(e);
+});
+
+window.addEventListener('appinstalled', e => {
+  logMessage('Got appinstalled!!!');
+});

--- a/ios_and_web/index.js
+++ b/ios_and_web/index.js
@@ -96,3 +96,25 @@ window.addEventListener('beforeinstallprompt', async e => {
 window.addEventListener('appinstalled', e => {
   logMessage('Got appinstalled!!!');
 });
+
+window.addEventListener('load', async e => {
+  if (navigator.getInstalledRelatedApps === undefined) {
+    logMessage('navigator.getInstalledRelatedApps is undefined');
+  } else {
+    let relatedApps;
+    try {
+      relatedApps = await navigator.getInstalledRelatedApps();
+    } catch (error) {
+      logMessage('getInstalledRelatedApps error: ' + error, true);
+      return;
+    }
+    logMessage('Installed related apps:');
+    for (let i = 0; i < relatedApps.length; i++) {
+      let app = relatedApps[i];
+      text = `id: ${JSON.stringify(app.id)}, `
+             + `platform: ${JSON.stringify(app.platform)}, `
+             + `url: ${JSON.stringify(app.url)}`;
+      logMessage(text);
+    }
+  }
+});

--- a/ios_and_web/index.js
+++ b/ios_and_web/index.js
@@ -8,7 +8,10 @@ if ('serviceWorker' in navigator) {
   });
 }
 
+e_copy = null;
+
 window.addEventListener("beforeinstallprompt", function(e) {
+  e_copy = e;
   document.open();
   document.write('Got beforeinstallprompt!!!<br>');
   document.write('platforms: ');
@@ -19,6 +22,22 @@ window.addEventListener("beforeinstallprompt", function(e) {
     e.preventDefault();
   } else {
     document.write("No, let's see the banner");
+    document.write("<br>The promise is: " + e_copy.userChoice);
+    window.setTimeout(onTimer, 1000);
   }
   document.close();
 });
+
+function onTimer() {
+  if (!e_copy) {
+    document.write("No event????");
+    return;
+  }
+  document.write("Timer time!<br>");
+  e_copy.userChoice.then(function(result) {
+    document.write("platform is: '" + result.platform + "'<br>");
+    document.write("outcome is: '" + result.outcome + "'");
+  }, function() {
+    document.write('Boo! an error');
+  });
+}

--- a/none/index.html
+++ b/none/index.html
@@ -6,5 +6,6 @@
 <body>
   <h1>Marmots are the best.</h1>
   <p>Site with no manifest.</p>
+  <div id="logs"></div>
 </body>
 </html>

--- a/none/index.js
+++ b/none/index.js
@@ -1,43 +1,98 @@
 if ('serviceWorker' in navigator) {
-  navigator.serviceWorker.register('sw.js').then(function(registration) {
+  navigator.serviceWorker.register('sw.js').then(registration => {
     // Registration was successful
     console.log('ServiceWorker registration successful with scope: ',    registration.scope);
-  }).catch(function(err) {
+  }).catch(err => {
     // registration failed :(
     console.log('ServiceWorker registration failed: ', err);
   });
 }
 
-e_copy = null;
-
-window.addEventListener("beforeinstallprompt", function(e) {
-  e_copy = e;
-  document.open();
-  document.write('Got beforeinstallprompt!!!<br>');
-  document.write('platforms: ');
-  document.write(e.platforms);
-  document.write('<br>Should I cancel it? Hmmmm .... ');
-  if (Math.random() > 0.5) {
-    document.write('Yeah why not. Cancelled!');
-    e.preventDefault();
-  } else {
-    document.write("No, let's see the banner");
-    document.write("<br>The promise is: " + e_copy.userChoice);
-    window.setTimeout(onTimer, 1000);
-  }
-  document.close();
-});
-
-function onTimer() {
-  if (!e_copy) {
-    document.write("No event????");
-    return;
-  }
-  document.write("Timer time!<br>");
-  e_copy.userChoice.then(function(result) {
-    document.write("platform is: '" + result.platform + "'<br>");
-    document.write("outcome is: '" + result.outcome + "'");
-  }, function() {
-    document.write('Boo! an error');
+// Creates a promise that resolves after a given number of milliseconds.
+function sleep(milliseconds) {
+  return new Promise((resolve, reject) => {
+      window.setTimeout(resolve, milliseconds);
   });
 }
+
+// Logs a message to the page, and console.
+function logMessage(message, isError) {
+  // Insert a paragraph into the page.
+  var logsDiv = document.querySelector('#logs');
+  var p = document.createElement('p');
+  logsDiv.appendChild(p);
+  p.appendChild(document.createTextNode(message));
+  if (isError)
+    p.style.color = 'red';
+
+  // Also log to the console.
+  if (isError)
+    console.error(message);
+  else
+    console.log(message);
+}
+
+// Logs a clickable link to the page. Returns a promise that resolves when the
+// user clicks the link.
+function logClickableLink(text) {
+  // Insert a paragraph into the page.
+  var logsDiv = document.querySelector('#logs');
+  var p = document.createElement('p');
+  logsDiv.appendChild(p);
+  var a = document.createElement('a');
+  p.appendChild(a);
+  a.setAttribute('href', '');
+  a.appendChild(document.createTextNode(text));
+
+  return new Promise((resolve, reject) => {
+    a.addEventListener('click', e => {
+      e.preventDefault();
+      resolve()
+    });
+  });
+}
+
+async function logUserChoice(e) {
+  logMessage('userChoice is: ' + e.userChoice);
+  await sleep(1000);
+  if (!e) {
+    logMessage('No event????', true);
+    return;
+  }
+
+  logMessage('Timer time!');
+  try {
+    let {platform, outcome} = await e.userChoice;
+    logMessage('platform is: \'' + platform + '\'');
+    logMessage('outcome is: \'' + outcome + '\'');
+  } catch (e) {
+    logMessage('Boo! an error', true);
+  }
+}
+
+window.addEventListener('beforeinstallprompt', async e => {
+  logMessage('Got beforeinstallprompt!!!');
+  logMessage('platforms: ' + e.platforms);
+  logMessage('Should I cancel it? Hmmmm .... ');
+
+  if (Math.random() > 0.5) {
+    logMessage('Yeah why not. Cancelled!');
+    e.preventDefault();
+    await logClickableLink('Show the prompt after all.');
+    try {
+      await e.prompt();
+      logMessage('prompt() resolved');
+    } catch (ex) {
+      logMessage('prompt() rejected with ' + ex, true);
+    }
+    logUserChoice(e);
+    return;
+  }
+
+  logMessage('No, let\'s see the banner');
+  logUserChoice(e);
+});
+
+window.addEventListener('appinstalled', e => {
+  logMessage('Got appinstalled!!!');
+});

--- a/none/index.js
+++ b/none/index.js
@@ -96,3 +96,25 @@ window.addEventListener('beforeinstallprompt', async e => {
 window.addEventListener('appinstalled', e => {
   logMessage('Got appinstalled!!!');
 });
+
+window.addEventListener('load', async e => {
+  if (navigator.getInstalledRelatedApps === undefined) {
+    logMessage('navigator.getInstalledRelatedApps is undefined');
+  } else {
+    let relatedApps;
+    try {
+      relatedApps = await navigator.getInstalledRelatedApps();
+    } catch (error) {
+      logMessage('getInstalledRelatedApps error: ' + error, true);
+      return;
+    }
+    logMessage('Installed related apps:');
+    for (let i = 0; i < relatedApps.length; i++) {
+      let app = relatedApps[i];
+      text = `id: ${JSON.stringify(app.id)}, `
+             + `platform: ${JSON.stringify(app.platform)}, `
+             + `url: ${JSON.stringify(app.url)}`;
+      logMessage(text);
+    }
+  }
+});

--- a/none/index.js
+++ b/none/index.js
@@ -7,3 +7,18 @@ if ('serviceWorker' in navigator) {
     console.log('ServiceWorker registration failed: ', err);
   });
 }
+
+window.addEventListener("beforeinstallprompt", function(e) {
+  document.open();
+  document.write('Got beforeinstallprompt!!!<br>');
+  document.write('platforms: ');
+  document.write(e.platforms);
+  document.write('<br>Should I cancel it? Hmmmm .... ');
+  if (Math.random() > 0.5) {
+    document.write('Yeah why not. Cancelled!');
+    e.preventDefault();
+  } else {
+    document.write("No, let's see the banner");
+  }
+  document.close();
+});

--- a/none/index.js
+++ b/none/index.js
@@ -8,7 +8,10 @@ if ('serviceWorker' in navigator) {
   });
 }
 
+e_copy = null;
+
 window.addEventListener("beforeinstallprompt", function(e) {
+  e_copy = e;
   document.open();
   document.write('Got beforeinstallprompt!!!<br>');
   document.write('platforms: ');
@@ -19,6 +22,22 @@ window.addEventListener("beforeinstallprompt", function(e) {
     e.preventDefault();
   } else {
     document.write("No, let's see the banner");
+    document.write("<br>The promise is: " + e_copy.userChoice);
+    window.setTimeout(onTimer, 1000);
   }
   document.close();
 });
+
+function onTimer() {
+  if (!e_copy) {
+    document.write("No event????");
+    return;
+  }
+  document.write("Timer time!<br>");
+  e_copy.userChoice.then(function(result) {
+    document.write("platform is: '" + result.platform + "'<br>");
+    document.write("outcome is: '" + result.outcome + "'");
+  }, function() {
+    document.write('Boo! an error');
+  });
+}

--- a/none/sw.js
+++ b/none/sw.js
@@ -1,9 +1,9 @@
 importScripts('../serviceworker-cache-polyfill.js');
 
-var CACHE_NAME = 'killer-marmot-v1';
+var CACHE_NAME = 'killer-marmot-v2';
 var urlsToCache = [
-  'index.js',
-  'index.html'
+//  'index.js',
+//  'index.html'
 ];
 
 self.addEventListener('install', function(event) {
@@ -17,42 +17,6 @@ self.addEventListener('install', function(event) {
   );
 });
 
+// Required to be installable.
 self.addEventListener('fetch', function(event) {
-  event.respondWith(
-    caches.match(event.request)
-      .then(function(response) {
-        // Cache hit - return response
-        if (response) {
-          return response;
-        }
-
-        // IMPORTANT: Clone the request. A request is a stream and
-        // can only be consumed once. Since we are consuming this
-        // once by cache and once by the browser for fetch, we need
-        // to clone the response
-        var fetchRequest = event.request.clone();
-
-        return fetch(fetchRequest).then(
-          function(response) {
-            // Check if we received a valid response
-            if(!response || response.status !== 200 || response.type !== 'basic') {
-              return response;
-            }
-
-            // IMPORTANT: Clone the response. A response is a stream
-            // and because we want the browser to consume the response
-            // as well as the cache consuming the response, we need
-            // to clone it so we have 2 stream.
-            var responseToCache = response.clone();
-
-            caches.open(CACHE_NAME)
-              .then(function(cache) {
-                cache.put(event.request, responseToCache);
-              });
-
-            return response;
-          }
-        );
-      })
-    );
 });

--- a/play_and_web/index.html
+++ b/play_and_web/index.html
@@ -7,5 +7,6 @@
 <body>
   <h1>Marmots are the best.</h1>
   <p>Site which is a valid web app, but has a preferred play app in its manifest.</p>
+  <div id="logs"></div>
 </body>
 </html>

--- a/play_and_web/index.js
+++ b/play_and_web/index.js
@@ -1,43 +1,98 @@
 if ('serviceWorker' in navigator) {
-  navigator.serviceWorker.register('sw.js').then(function(registration) {
+  navigator.serviceWorker.register('sw.js').then(registration => {
     // Registration was successful
     console.log('ServiceWorker registration successful with scope: ',    registration.scope);
-  }).catch(function(err) {
+  }).catch(err => {
     // registration failed :(
     console.log('ServiceWorker registration failed: ', err);
   });
 }
 
-e_copy = null;
-
-window.addEventListener("beforeinstallprompt", function(e) {
-  e_copy = e;
-  document.open();
-  document.write('Got beforeinstallprompt!!!<br>');
-  document.write('platforms: ');
-  document.write(e.platforms);
-  document.write('<br>Should I cancel it? Hmmmm .... ');
-  if (Math.random() > 0.5) {
-    document.write('Yeah why not. Cancelled!');
-    e.preventDefault();
-  } else {
-    document.write("No, let's see the banner");
-    document.write("<br>The promise is: " + e_copy.userChoice);
-    window.setTimeout(onTimer, 1000);
-  }
-  document.close();
-});
-
-function onTimer() {
-  if (!e_copy) {
-    document.write("No event????");
-    return;
-  }
-  document.write("Timer time!<br>");
-  e_copy.userChoice.then(function(result) {
-    document.write("platform is: '" + result.platform + "'<br>");
-    document.write("outcome is: '" + result.outcome + "'");
-  }, function() {
-    document.write('Boo! an error');
+// Creates a promise that resolves after a given number of milliseconds.
+function sleep(milliseconds) {
+  return new Promise((resolve, reject) => {
+      window.setTimeout(resolve, milliseconds);
   });
 }
+
+// Logs a message to the page, and console.
+function logMessage(message, isError) {
+  // Insert a paragraph into the page.
+  var logsDiv = document.querySelector('#logs');
+  var p = document.createElement('p');
+  logsDiv.appendChild(p);
+  p.appendChild(document.createTextNode(message));
+  if (isError)
+    p.style.color = 'red';
+
+  // Also log to the console.
+  if (isError)
+    console.error(message);
+  else
+    console.log(message);
+}
+
+// Logs a clickable link to the page. Returns a promise that resolves when the
+// user clicks the link.
+function logClickableLink(text) {
+  // Insert a paragraph into the page.
+  var logsDiv = document.querySelector('#logs');
+  var p = document.createElement('p');
+  logsDiv.appendChild(p);
+  var a = document.createElement('a');
+  p.appendChild(a);
+  a.setAttribute('href', '');
+  a.appendChild(document.createTextNode(text));
+
+  return new Promise((resolve, reject) => {
+    a.addEventListener('click', e => {
+      e.preventDefault();
+      resolve()
+    });
+  });
+}
+
+async function logUserChoice(e) {
+  logMessage('userChoice is: ' + e.userChoice);
+  await sleep(1000);
+  if (!e) {
+    logMessage('No event????', true);
+    return;
+  }
+
+  logMessage('Timer time!');
+  try {
+    let {platform, outcome} = await e.userChoice;
+    logMessage('platform is: \'' + platform + '\'');
+    logMessage('outcome is: \'' + outcome + '\'');
+  } catch (e) {
+    logMessage('Boo! an error', true);
+  }
+}
+
+window.addEventListener('beforeinstallprompt', async e => {
+  logMessage('Got beforeinstallprompt!!!');
+  logMessage('platforms: ' + e.platforms);
+  logMessage('Should I cancel it? Hmmmm .... ');
+
+  if (Math.random() > 0.5) {
+    logMessage('Yeah why not. Cancelled!');
+    e.preventDefault();
+    await logClickableLink('Show the prompt after all.');
+    try {
+      await e.prompt();
+      logMessage('prompt() resolved');
+    } catch (ex) {
+      logMessage('prompt() rejected with ' + ex, true);
+    }
+    logUserChoice(e);
+    return;
+  }
+
+  logMessage('No, let\'s see the banner');
+  logUserChoice(e);
+});
+
+window.addEventListener('appinstalled', e => {
+  logMessage('Got appinstalled!!!');
+});

--- a/play_and_web/index.js
+++ b/play_and_web/index.js
@@ -96,3 +96,25 @@ window.addEventListener('beforeinstallprompt', async e => {
 window.addEventListener('appinstalled', e => {
   logMessage('Got appinstalled!!!');
 });
+
+window.addEventListener('load', async e => {
+  if (navigator.getInstalledRelatedApps === undefined) {
+    logMessage('navigator.getInstalledRelatedApps is undefined');
+  } else {
+    let relatedApps;
+    try {
+      relatedApps = await navigator.getInstalledRelatedApps();
+    } catch (error) {
+      logMessage('getInstalledRelatedApps error: ' + error, true);
+      return;
+    }
+    logMessage('Installed related apps:');
+    for (let i = 0; i < relatedApps.length; i++) {
+      let app = relatedApps[i];
+      text = `id: ${JSON.stringify(app.id)}, `
+             + `platform: ${JSON.stringify(app.platform)}, `
+             + `url: ${JSON.stringify(app.url)}`;
+      logMessage(text);
+    }
+  }
+});

--- a/play_and_web/index.js
+++ b/play_and_web/index.js
@@ -8,7 +8,10 @@ if ('serviceWorker' in navigator) {
   });
 }
 
+e_copy = null;
+
 window.addEventListener("beforeinstallprompt", function(e) {
+  e_copy = e;
   document.open();
   document.write('Got beforeinstallprompt!!!<br>');
   document.write('platforms: ');
@@ -19,6 +22,22 @@ window.addEventListener("beforeinstallprompt", function(e) {
     e.preventDefault();
   } else {
     document.write("No, let's see the banner");
+    document.write("<br>The promise is: " + e_copy.userChoice);
+    window.setTimeout(onTimer, 1000);
   }
   document.close();
 });
+
+function onTimer() {
+  if (!e_copy) {
+    document.write("No event????");
+    return;
+  }
+  document.write("Timer time!<br>");
+  e_copy.userChoice.then(function(result) {
+    document.write("platform is: '" + result.platform + "'<br>");
+    document.write("outcome is: '" + result.outcome + "'");
+  }, function() {
+    document.write('Boo! an error');
+  });
+}

--- a/web/index.js
+++ b/web/index.js
@@ -96,3 +96,25 @@ window.addEventListener('beforeinstallprompt', async e => {
 window.addEventListener('appinstalled', e => {
   logMessage('Got appinstalled!!!');
 });
+
+window.addEventListener('load', async e => {
+  if (navigator.getInstalledRelatedApps === undefined) {
+    logMessage('navigator.getInstalledRelatedApps is undefined');
+  } else {
+    let relatedApps;
+    try {
+      relatedApps = await navigator.getInstalledRelatedApps();
+    } catch (error) {
+      logMessage('getInstalledRelatedApps error: ' + error, true);
+      return;
+    }
+    logMessage('Installed related apps:');
+    for (let i = 0; i < relatedApps.length; i++) {
+      let app = relatedApps[i];
+      text = `id: ${JSON.stringify(app.id)}, `
+             + `platform: ${JSON.stringify(app.platform)}, `
+             + `url: ${JSON.stringify(app.url)}`;
+      logMessage(text);
+    }
+  }
+});

--- a/web_and_ios/index.html
+++ b/web_and_ios/index.html
@@ -7,5 +7,6 @@
 <body>
   <h1>Marmots are the best.</h1>
   <p>Site which is a valid web app, and also with a non-preferred iOS app in its manifest.</p>
+  <div id="logs"></div>
 </body>
 </html>

--- a/web_and_ios/index.js
+++ b/web_and_ios/index.js
@@ -1,43 +1,98 @@
 if ('serviceWorker' in navigator) {
-  navigator.serviceWorker.register('sw.js').then(function(registration) {
+  navigator.serviceWorker.register('sw.js').then(registration => {
     // Registration was successful
     console.log('ServiceWorker registration successful with scope: ',    registration.scope);
-  }).catch(function(err) {
+  }).catch(err => {
     // registration failed :(
     console.log('ServiceWorker registration failed: ', err);
   });
 }
 
-e_copy = null;
-
-window.addEventListener("beforeinstallprompt", function(e) {
-  e_copy = e;
-  document.open();
-  document.write('Got beforeinstallprompt!!!<br>');
-  document.write('platforms: ');
-  document.write(e.platforms);
-  document.write('<br>Should I cancel it? Hmmmm .... ');
-  if (Math.random() > 0.5) {
-    document.write('Yeah why not. Cancelled!');
-    e.preventDefault();
-  } else {
-    document.write("No, let's see the banner");
-    document.write("<br>The promise is: " + e_copy.userChoice);
-    window.setTimeout(onTimer, 1000);
-  }
-  document.close();
-});
-
-function onTimer() {
-  if (!e_copy) {
-    document.write("No event????");
-    return;
-  }
-  document.write("Timer time!<br>");
-  e_copy.userChoice.then(function(result) {
-    document.write("platform is: '" + result.platform + "'<br>");
-    document.write("outcome is: '" + result.outcome + "'");
-  }, function() {
-    document.write('Boo! an error');
+// Creates a promise that resolves after a given number of milliseconds.
+function sleep(milliseconds) {
+  return new Promise((resolve, reject) => {
+      window.setTimeout(resolve, milliseconds);
   });
 }
+
+// Logs a message to the page, and console.
+function logMessage(message, isError) {
+  // Insert a paragraph into the page.
+  var logsDiv = document.querySelector('#logs');
+  var p = document.createElement('p');
+  logsDiv.appendChild(p);
+  p.appendChild(document.createTextNode(message));
+  if (isError)
+    p.style.color = 'red';
+
+  // Also log to the console.
+  if (isError)
+    console.error(message);
+  else
+    console.log(message);
+}
+
+// Logs a clickable link to the page. Returns a promise that resolves when the
+// user clicks the link.
+function logClickableLink(text) {
+  // Insert a paragraph into the page.
+  var logsDiv = document.querySelector('#logs');
+  var p = document.createElement('p');
+  logsDiv.appendChild(p);
+  var a = document.createElement('a');
+  p.appendChild(a);
+  a.setAttribute('href', '');
+  a.appendChild(document.createTextNode(text));
+
+  return new Promise((resolve, reject) => {
+    a.addEventListener('click', e => {
+      e.preventDefault();
+      resolve()
+    });
+  });
+}
+
+async function logUserChoice(e) {
+  logMessage('userChoice is: ' + e.userChoice);
+  await sleep(1000);
+  if (!e) {
+    logMessage('No event????', true);
+    return;
+  }
+
+  logMessage('Timer time!');
+  try {
+    let {platform, outcome} = await e.userChoice;
+    logMessage('platform is: \'' + platform + '\'');
+    logMessage('outcome is: \'' + outcome + '\'');
+  } catch (e) {
+    logMessage('Boo! an error', true);
+  }
+}
+
+window.addEventListener('beforeinstallprompt', async e => {
+  logMessage('Got beforeinstallprompt!!!');
+  logMessage('platforms: ' + e.platforms);
+  logMessage('Should I cancel it? Hmmmm .... ');
+
+  if (Math.random() > 0.5) {
+    logMessage('Yeah why not. Cancelled!');
+    e.preventDefault();
+    await logClickableLink('Show the prompt after all.');
+    try {
+      await e.prompt();
+      logMessage('prompt() resolved');
+    } catch (ex) {
+      logMessage('prompt() rejected with ' + ex, true);
+    }
+    logUserChoice(e);
+    return;
+  }
+
+  logMessage('No, let\'s see the banner');
+  logUserChoice(e);
+});
+
+window.addEventListener('appinstalled', e => {
+  logMessage('Got appinstalled!!!');
+});

--- a/web_and_ios/index.js
+++ b/web_and_ios/index.js
@@ -96,3 +96,25 @@ window.addEventListener('beforeinstallprompt', async e => {
 window.addEventListener('appinstalled', e => {
   logMessage('Got appinstalled!!!');
 });
+
+window.addEventListener('load', async e => {
+  if (navigator.getInstalledRelatedApps === undefined) {
+    logMessage('navigator.getInstalledRelatedApps is undefined');
+  } else {
+    let relatedApps;
+    try {
+      relatedApps = await navigator.getInstalledRelatedApps();
+    } catch (error) {
+      logMessage('getInstalledRelatedApps error: ' + error, true);
+      return;
+    }
+    logMessage('Installed related apps:');
+    for (let i = 0; i < relatedApps.length; i++) {
+      let app = relatedApps[i];
+      text = `id: ${JSON.stringify(app.id)}, `
+             + `platform: ${JSON.stringify(app.platform)}, `
+             + `url: ${JSON.stringify(app.url)}`;
+      logMessage(text);
+    }
+  }
+});

--- a/web_and_ios/index.js
+++ b/web_and_ios/index.js
@@ -7,3 +7,18 @@ if ('serviceWorker' in navigator) {
     console.log('ServiceWorker registration failed: ', err);
   });
 }
+
+window.addEventListener("beforeinstallprompt", function(e) {
+  document.open();
+  document.write('Got beforeinstallprompt!!!<br>');
+  document.write('platforms: ');
+  document.write(e.platforms);
+  document.write('<br>Should I cancel it? Hmmmm .... ');
+  if (Math.random() > 0.5) {
+    document.write('Yeah why not. Cancelled!');
+    e.preventDefault();
+  } else {
+    document.write("No, let's see the banner");
+  }
+  document.close();
+});

--- a/web_and_ios/index.js
+++ b/web_and_ios/index.js
@@ -8,7 +8,10 @@ if ('serviceWorker' in navigator) {
   });
 }
 
+e_copy = null;
+
 window.addEventListener("beforeinstallprompt", function(e) {
+  e_copy = e;
   document.open();
   document.write('Got beforeinstallprompt!!!<br>');
   document.write('platforms: ');
@@ -19,6 +22,22 @@ window.addEventListener("beforeinstallprompt", function(e) {
     e.preventDefault();
   } else {
     document.write("No, let's see the banner");
+    document.write("<br>The promise is: " + e_copy.userChoice);
+    window.setTimeout(onTimer, 1000);
   }
   document.close();
 });
+
+function onTimer() {
+  if (!e_copy) {
+    document.write("No event????");
+    return;
+  }
+  document.write("Timer time!<br>");
+  e_copy.userChoice.then(function(result) {
+    document.write("platform is: '" + result.platform + "'<br>");
+    document.write("outcome is: '" + result.outcome + "'");
+  }, function() {
+    document.write('Boo! an error');
+  });
+}

--- a/web_and_play/index.js
+++ b/web_and_play/index.js
@@ -1,10 +1,17 @@
 if ('serviceWorker' in navigator) {
-  navigator.serviceWorker.register('sw.js').then(function(registration) {
+  navigator.serviceWorker.register('sw.js').then(registration => {
     // Registration was successful
     console.log('ServiceWorker registration successful with scope: ',    registration.scope);
-  }).catch(function(err) {
+  }).catch(err => {
     // registration failed :(
     console.log('ServiceWorker registration failed: ', err);
+  });
+}
+
+// Creates a promise that resolves after a given number of milliseconds.
+function sleep(milliseconds) {
+  return new Promise((resolve, reject) => {
+      window.setTimeout(resolve, milliseconds);
   });
 }
 
@@ -25,17 +32,69 @@ function logMessage(message, isError) {
     console.log(message);
 }
 
-window.addEventListener("beforeinstallprompt", function(e) {
-  logMessage('Got beforeinstallprompt!!!<br>');
-  logMessage('platforms: ');
-  logMessage(e.platforms);
-  logMessage('<br>Should I cancel it? Hmmmm .... ');
+// Logs a clickable link to the page. Returns a promise that resolves when the
+// user clicks the link.
+function logClickableLink(text) {
+  // Insert a paragraph into the page.
+  var logsDiv = document.querySelector('#logs');
+  var p = document.createElement('p');
+  logsDiv.appendChild(p);
+  var a = document.createElement('a');
+  p.appendChild(a);
+  a.setAttribute('href', '');
+  a.appendChild(document.createTextNode(text));
+
+  return new Promise((resolve, reject) => {
+    a.addEventListener('click', e => {
+      e.preventDefault();
+      resolve()
+    });
+  });
+}
+
+async function logUserChoice(e) {
+  logMessage('userChoice is: ' + e.userChoice);
+  await sleep(1000);
+  if (!e) {
+    logMessage('No event????', true);
+    return;
+  }
+
+  logMessage('Timer time!');
+  try {
+    let {platform, outcome} = await e.userChoice;
+    logMessage('platform is: \'' + platform + '\'');
+    logMessage('outcome is: \'' + outcome + '\'');
+  } catch (e) {
+    logMessage('Boo! an error', true);
+  }
+}
+
+window.addEventListener('beforeinstallprompt', async e => {
+  logMessage('Got beforeinstallprompt!!!');
+  logMessage('platforms: ' + e.platforms);
+  logMessage('Should I cancel it? Hmmmm .... ');
+
   if (Math.random() > 0.5) {
     logMessage('Yeah why not. Cancelled!');
     e.preventDefault();
-  } else {
-    logMessage("No, let's see the banner");
+    await logClickableLink('Show the prompt after all.');
+    try {
+      await e.prompt();
+      logMessage('prompt() resolved');
+    } catch (ex) {
+      logMessage('prompt() rejected with ' + ex, true);
+    }
+    logUserChoice(e);
+    return;
   }
+
+  logMessage('No, let\'s see the banner');
+  logUserChoice(e);
+});
+
+window.addEventListener('appinstalled', e => {
+  logMessage('Got appinstalled!!!');
 });
 
 window.addEventListener('load', async e => {

--- a/web_broken/index.html
+++ b/web_broken/index.html
@@ -8,5 +8,6 @@
 <body>
   <h1>Marmots are the best.</h1>
   <p>Site which is a valid web app. v12.</p>
+  <div id="logs"></div>
 </body>
 </html>

--- a/web_broken/index.js
+++ b/web_broken/index.js
@@ -1,43 +1,98 @@
 if ('serviceWorker' in navigator) {
-  navigator.serviceWorker.register('sw.js').then(function(registration) {
+  navigator.serviceWorker.register('sw.js').then(registration => {
     // Registration was successful
     console.log('ServiceWorker registration successful with scope: ',    registration.scope);
-  }).catch(function(err) {
+  }).catch(err => {
     // registration failed :(
     console.log('ServiceWorker registration failed: ', err);
   });
 }
 
-e_copy = null;
-
-window.addEventListener("beforeinstallprompt", function(e) {
-  e_copy = e;
-  document.open();
-  document.write('Got beforeinstallprompt!!!<br>');
-  document.write('platforms: ');
-  document.write(e.platforms);
-  document.write('<br>Should I cancel it? Hmmmm .... ');
-  if (Math.random() > 0.5) {
-    document.write('Yeah why not. Cancelled!');
-    e.preventDefault();
-  } else {
-    document.write("No, let's see the banner");
-    document.write("<br>The promise is: " + e_copy.userChoice);
-    window.setTimeout(onTimer, 1000);
-  }
-  document.close();
-});
-
-function onTimer() {
-  if (!e_copy) {
-    document.write("No event????");
-    return;
-  }
-  document.write("Timer time!<br>");
-  e_copy.userChoice.then(function(result) {
-    document.write("platform is: '" + result.platform + "'<br>");
-    document.write("outcome is: '" + result.outcome + "'");
-  }, function() {
-    document.write('Boo! an error');
+// Creates a promise that resolves after a given number of milliseconds.
+function sleep(milliseconds) {
+  return new Promise((resolve, reject) => {
+      window.setTimeout(resolve, milliseconds);
   });
 }
+
+// Logs a message to the page, and console.
+function logMessage(message, isError) {
+  // Insert a paragraph into the page.
+  var logsDiv = document.querySelector('#logs');
+  var p = document.createElement('p');
+  logsDiv.appendChild(p);
+  p.appendChild(document.createTextNode(message));
+  if (isError)
+    p.style.color = 'red';
+
+  // Also log to the console.
+  if (isError)
+    console.error(message);
+  else
+    console.log(message);
+}
+
+// Logs a clickable link to the page. Returns a promise that resolves when the
+// user clicks the link.
+function logClickableLink(text) {
+  // Insert a paragraph into the page.
+  var logsDiv = document.querySelector('#logs');
+  var p = document.createElement('p');
+  logsDiv.appendChild(p);
+  var a = document.createElement('a');
+  p.appendChild(a);
+  a.setAttribute('href', '');
+  a.appendChild(document.createTextNode(text));
+
+  return new Promise((resolve, reject) => {
+    a.addEventListener('click', e => {
+      e.preventDefault();
+      resolve()
+    });
+  });
+}
+
+async function logUserChoice(e) {
+  logMessage('userChoice is: ' + e.userChoice);
+  await sleep(1000);
+  if (!e) {
+    logMessage('No event????', true);
+    return;
+  }
+
+  logMessage('Timer time!');
+  try {
+    let {platform, outcome} = await e.userChoice;
+    logMessage('platform is: \'' + platform + '\'');
+    logMessage('outcome is: \'' + outcome + '\'');
+  } catch (e) {
+    logMessage('Boo! an error', true);
+  }
+}
+
+window.addEventListener('beforeinstallprompt', async e => {
+  logMessage('Got beforeinstallprompt!!!');
+  logMessage('platforms: ' + e.platforms);
+  logMessage('Should I cancel it? Hmmmm .... ');
+
+  if (Math.random() > 0.5) {
+    logMessage('Yeah why not. Cancelled!');
+    e.preventDefault();
+    await logClickableLink('Show the prompt after all.');
+    try {
+      await e.prompt();
+      logMessage('prompt() resolved');
+    } catch (ex) {
+      logMessage('prompt() rejected with ' + ex, true);
+    }
+    logUserChoice(e);
+    return;
+  }
+
+  logMessage('No, let\'s see the banner');
+  logUserChoice(e);
+});
+
+window.addEventListener('appinstalled', e => {
+  logMessage('Got appinstalled!!!');
+});

--- a/web_broken/index.js
+++ b/web_broken/index.js
@@ -96,3 +96,25 @@ window.addEventListener('beforeinstallprompt', async e => {
 window.addEventListener('appinstalled', e => {
   logMessage('Got appinstalled!!!');
 });
+
+window.addEventListener('load', async e => {
+  if (navigator.getInstalledRelatedApps === undefined) {
+    logMessage('navigator.getInstalledRelatedApps is undefined');
+  } else {
+    let relatedApps;
+    try {
+      relatedApps = await navigator.getInstalledRelatedApps();
+    } catch (error) {
+      logMessage('getInstalledRelatedApps error: ' + error, true);
+      return;
+    }
+    logMessage('Installed related apps:');
+    for (let i = 0; i < relatedApps.length; i++) {
+      let app = relatedApps[i];
+      text = `id: ${JSON.stringify(app.id)}, `
+             + `platform: ${JSON.stringify(app.platform)}, `
+             + `url: ${JSON.stringify(app.url)}`;
+      logMessage(text);
+    }
+  }
+});

--- a/web_no_meta_viewport/index.html
+++ b/web_no_meta_viewport/index.html
@@ -8,5 +8,6 @@
 <body>
   <h1>Marmots are the best.</h1>
   <p>Site which is a valid web app. v12.</p>
+  <div id="logs"></div>
 </body>
 </html>

--- a/web_no_meta_viewport/index.js
+++ b/web_no_meta_viewport/index.js
@@ -1,25 +1,120 @@
 if ('serviceWorker' in navigator) {
-  navigator.serviceWorker.register('sw.js').then(function(registration) {
+  navigator.serviceWorker.register('sw.js').then(registration => {
     // Registration was successful
     console.log('ServiceWorker registration successful with scope: ',    registration.scope);
-  }).catch(function(err) {
+  }).catch(err => {
     // registration failed :(
     console.log('ServiceWorker registration failed: ', err);
   });
 }
 
-var isTooSoon = (window.location.hash == "#redispatch");
-window.addEventListener("beforeinstallprompt", function(e) {
-  console.log(e);
-  if (isTooSoon) {
-    e.preventDefault(); // Prevents prompt display
-    console.log("Delaying event!");
-    // Prompt later instead:
-    setTimeout(function() {
-      isTooSoon = false;
-      console.log("Dispatching event");
-      e.prompt() // Shows prompt
-      console.log(e);
-    }, 5000);
+// Creates a promise that resolves after a given number of milliseconds.
+function sleep(milliseconds) {
+  return new Promise((resolve, reject) => {
+      window.setTimeout(resolve, milliseconds);
+  });
+}
+
+// Logs a message to the page, and console.
+function logMessage(message, isError) {
+  // Insert a paragraph into the page.
+  var logsDiv = document.querySelector('#logs');
+  var p = document.createElement('p');
+  logsDiv.appendChild(p);
+  p.appendChild(document.createTextNode(message));
+  if (isError)
+    p.style.color = 'red';
+
+  // Also log to the console.
+  if (isError)
+    console.error(message);
+  else
+    console.log(message);
+}
+
+// Logs a clickable link to the page. Returns a promise that resolves when the
+// user clicks the link.
+function logClickableLink(text) {
+  // Insert a paragraph into the page.
+  var logsDiv = document.querySelector('#logs');
+  var p = document.createElement('p');
+  logsDiv.appendChild(p);
+  var a = document.createElement('a');
+  p.appendChild(a);
+  a.setAttribute('href', '');
+  a.appendChild(document.createTextNode(text));
+
+  return new Promise((resolve, reject) => {
+    a.addEventListener('click', e => {
+      e.preventDefault();
+      resolve()
+    });
+  });
+}
+
+async function logUserChoice(e) {
+  logMessage('userChoice is: ' + e.userChoice);
+  await sleep(1000);
+  if (!e) {
+    logMessage('No event????', true);
+    return;
+  }
+
+  logMessage('Timer time!');
+  try {
+    let {platform, outcome} = await e.userChoice;
+    logMessage('platform is: \'' + platform + '\'');
+    logMessage('outcome is: \'' + outcome + '\'');
+  } catch (e) {
+    logMessage('Boo! an error', true);
+  }
+}
+
+window.addEventListener('beforeinstallprompt', async e => {
+  logMessage('Got beforeinstallprompt!!!');
+  logMessage('platforms: ' + e.platforms);
+  logMessage('Should I cancel it? Hmmmm .... ');
+
+  if (Math.random() > 0.5) {
+    logMessage('Yeah why not. Cancelled!');
+    e.preventDefault();
+    await logClickableLink('Show the prompt after all.');
+    try {
+      await e.prompt();
+      logMessage('prompt() resolved');
+    } catch (ex) {
+      logMessage('prompt() rejected with ' + ex, true);
+    }
+    logUserChoice(e);
+    return;
+  }
+
+  logMessage('No, let\'s see the banner');
+  logUserChoice(e);
+});
+
+window.addEventListener('appinstalled', e => {
+  logMessage('Got appinstalled!!!');
+});
+
+window.addEventListener('load', async e => {
+  if (navigator.getInstalledRelatedApps === undefined) {
+    logMessage('navigator.getInstalledRelatedApps is undefined');
+  } else {
+    let relatedApps;
+    try {
+      relatedApps = await navigator.getInstalledRelatedApps();
+    } catch (error) {
+      logMessage('getInstalledRelatedApps error: ' + error, true);
+      return;
+    }
+    logMessage('Installed related apps:');
+    for (let i = 0; i < relatedApps.length; i++) {
+      let app = relatedApps[i];
+      text = `id: ${JSON.stringify(app.id)}, `
+             + `platform: ${JSON.stringify(app.platform)}, `
+             + `url: ${JSON.stringify(app.url)}`;
+      logMessage(text);
+    }
   }
 });


### PR DESCRIPTION
This is getting unmanageable (especially when transitioning to a template-based system instead of a bunch of separate source trees).

This CL combines the "web" and "web_and_play" index.js files (which are the most advanced versions, and had diverged) into a single version, and copies it to all the apps. Now all apps will report on `beforeinstallprompt`, `appinstalled` and try to use `getInstalledRelatedApps`. The notable exception is "web_redispatch" which keeps its own code (will deal with this later).

Also removed "none"'s service worker and replaced it with the simpler service worker used elsewhere. This loses caching functionality, which should come back at some point, but is too annoying/primitive for development.