### PR TITLE
Update HTML and Manifest files for correctness and consistency.

### DIFF
--- a/ios/manifest.json
+++ b/ios/manifest.json
@@ -2,7 +2,8 @@
   "related_applications": [
     {
       "platform": "ios",
-      "id": "combgppybird"
+      "url": "https://itunes.apple.com/au/app/crappybird/id123456789"
     }
-  ]
+  ],
+  "prefer_related_applications": true
 }

--- a/ios_and_play/manifest.json
+++ b/ios_and_play/manifest.json
@@ -2,7 +2,7 @@
   "related_applications": [
     {
       "platform": "ios",
-      "id": "basdfasdf"
+      "url": "https://itunes.apple.com/au/app/crappybird/id123456789"
     },
     {
       "platform": "play",

--- a/ios_and_web/index.html
+++ b/ios_and_web/index.html
@@ -3,10 +3,11 @@
 <head>
   <script src="index.js"></script>
   <link rel="manifest" href="manifest.json">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
 </head>
 <body>
   <h1>Marmots are the best.</h1>
-  <p>Site which is a valid web app, but has a preferred iOS app in its manifest. v2.</p>
+  <p>Site which is a valid web app, but has a preferred iOS app in its manifest.</p>
   <div id="logs"></div>
 </body>
 </html>

--- a/ios_and_web/manifest.json
+++ b/ios_and_web/manifest.json
@@ -7,13 +7,44 @@
       "sizes": "any",
       "type": "image/png",
       "density": 1
+    },
+    {
+      "src": "../marmot_48.png",
+      "sizes": "48x48",
+      "type": "image/png",
+      "density": 1
+    },
+    {
+      "src": "../marmot_96.png",
+      "sizes": "96x96",
+      "type": "image/png",
+      "density": 1
+    },
+    {
+      "src": "../marmot_128.png",
+      "sizes": "128x128",
+      "type": "image/png",
+      "density": 1
+    },
+    {
+      "src": "../marmot_200.png",
+      "sizes": "200x200",
+      "type": "image/png",
+      "density": 1
+    },
+    {
+      "src": "../marmot_480.png",
+      "sizes": "480x480",
+      "type": "image/png",
+      "density": 1
     }
   ],
+  "display": "standalone",
   "start_url": "index.html",
   "related_applications": [
     {
       "platform": "ios",
-      "id": "blahblahathisis"
+      "url": "https://itunes.apple.com/au/app/crappybird/id123456789"
     }
   ],
   "prefer_related_applications": true

--- a/play_and_ios/manifest.json
+++ b/play_and_ios/manifest.json
@@ -6,7 +6,7 @@
     },
     {
       "platform": "ios",
-      "id": "basdfasdf"
+      "url": "https://itunes.apple.com/au/app/crappybird/id123456789"
     }
   ],
   "prefer_related_applications": true

--- a/play_and_web/index.html
+++ b/play_and_web/index.html
@@ -3,6 +3,7 @@
 <head>
   <script src="index.js"></script>
   <link rel="manifest" href="manifest.json">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
 </head>
 <body>
   <h1>Marmots are the best.</h1>

--- a/play_and_web/manifest.json
+++ b/play_and_web/manifest.json
@@ -7,8 +7,39 @@
       "sizes": "any",
       "type": "image/png",
       "density": 1
+    },
+    {
+      "src": "../marmot_48.png",
+      "sizes": "48x48",
+      "type": "image/png",
+      "density": 1
+    },
+    {
+      "src": "../marmot_96.png",
+      "sizes": "96x96",
+      "type": "image/png",
+      "density": 1
+    },
+    {
+      "src": "../marmot_128.png",
+      "sizes": "128x128",
+      "type": "image/png",
+      "density": 1
+    },
+    {
+      "src": "../marmot_200.png",
+      "sizes": "200x200",
+      "type": "image/png",
+      "density": 1
+    },
+    {
+      "src": "../marmot_480.png",
+      "sizes": "480x480",
+      "type": "image/png",
+      "density": 1
     }
   ],
+  "display": "standalone",
   "start_url": "index.html",
   "related_applications": [
     {

--- a/play_non_google_link_referrer/index.html
+++ b/play_non_google_link_referrer/index.html
@@ -6,6 +6,6 @@
 </head>
 <body>
   <h1>Marmots are the best.</h1>
-  <p>Site with a related play app in the manifest.</p>
+  <p>Site with a related play app (non-Play-Store referrer) in the manifest.</p>
 </body>
 </html>

--- a/play_referrer/index.html
+++ b/play_referrer/index.html
@@ -6,6 +6,6 @@
 </head>
 <body>
   <h1>Marmots are the best.</h1>
-  <p>Site with a related play app in the manifest.</p>
+  <p>Site with a related play app (Play Store referrer) in the manifest.</p>
 </body>
 </html>

--- a/web/index.html
+++ b/web/index.html
@@ -7,7 +7,7 @@
 </head>
 <body>
   <h1>Marmots are the best.</h1>
-  <p>Site which is a valid web app. v12.</p>
+  <p>Site which is a valid web app.</p>
   <div id="logs"></div>
 </body>
 </html>

--- a/web_and_ios/index.html
+++ b/web_and_ios/index.html
@@ -3,6 +3,7 @@
 <head>
   <script src="index.js"></script>
   <link rel="manifest" href="manifest.json">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
 </head>
 <body>
   <h1>Marmots are the best.</h1>

--- a/web_and_ios/manifest.json
+++ b/web_and_ios/manifest.json
@@ -7,6 +7,36 @@
       "sizes": "any",
       "type": "image/png",
       "density": 1
+    },
+    {
+      "src": "../marmot_48.png",
+      "sizes": "48x48",
+      "type": "image/png",
+      "density": 1
+    },
+    {
+      "src": "../marmot_96.png",
+      "sizes": "96x96",
+      "type": "image/png",
+      "density": 1
+    },
+    {
+      "src": "../marmot_128.png",
+      "sizes": "128x128",
+      "type": "image/png",
+      "density": 1
+    },
+    {
+      "src": "../marmot_200.png",
+      "sizes": "200x200",
+      "type": "image/png",
+      "density": 1
+    },
+    {
+      "src": "../marmot_480.png",
+      "sizes": "480x480",
+      "type": "image/png",
+      "density": 1
     }
   ],
   "display": "standalone",
@@ -14,7 +44,7 @@
   "related_applications": [
     {
       "platform": "ios",
-      "id": "blahblahblah"
+      "url": "https://itunes.apple.com/au/app/crappybird/id123456789"
     }
   ]
 }

--- a/web_and_play/index.html
+++ b/web_and_play/index.html
@@ -3,6 +3,7 @@
 <head>
   <script src="index.js"></script>
   <link rel="manifest" href="manifest.json">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
 </head>
 <body>
   <h1>Marmots are the best.</h1>

--- a/web_and_play/manifest.json
+++ b/web_and_play/manifest.json
@@ -7,6 +7,36 @@
       "sizes": "any",
       "type": "image/png",
       "density": 1
+    },
+    {
+      "src": "../marmot_48.png",
+      "sizes": "48x48",
+      "type": "image/png",
+      "density": 1
+    },
+    {
+      "src": "../marmot_96.png",
+      "sizes": "96x96",
+      "type": "image/png",
+      "density": 1
+    },
+    {
+      "src": "../marmot_128.png",
+      "sizes": "128x128",
+      "type": "image/png",
+      "density": 1
+    },
+    {
+      "src": "../marmot_200.png",
+      "sizes": "200x200",
+      "type": "image/png",
+      "density": 1
+    },
+    {
+      "src": "../marmot_480.png",
+      "sizes": "480x480",
+      "type": "image/png",
+      "density": 1
     }
   ],
   "display": "standalone",

--- a/web_broken/index.html
+++ b/web_broken/index.html
@@ -7,7 +7,7 @@
 </head>
 <body>
   <h1>Marmots are the best.</h1>
-  <p>Site which is a valid web app. v12.</p>
+  <p>Site which is a broken web app.</p>
   <div id="logs"></div>
 </body>
 </html>

--- a/web_broken/manifest.json
+++ b/web_broken/manifest.json
@@ -3,37 +3,37 @@
   "short_name": "Marmot",
   "icons": [
     {
-      "src": "../marmot1.png",
+      "src": "../missing.png",
       "sizes": "any",
       "type": "image/png",
       "density": 1
     },
     {
-      "src": "../marmot_481.png",
+      "src": "../missing_48.png",
       "sizes": "48",
       "type": "image/png",
       "density": 1
     },
     {
-      "src": "../marmot_961.png",
+      "src": "../missing_96.png",
       "sizes": "96",
       "type": "image/png",
       "density": 1
     },
     {
-      "src": "../marmot_1281.png",
+      "src": "../missing_128.png",
       "sizes": "128",
       "type": "image/png",
       "density": 1
     },
     {
-      "src": "../marmot_2001.png",
+      "src": "../missing_200.png",
       "sizes": "200",
       "type": "image/png",
       "density": 1
     },
     {
-      "src": "../marmot_4801.png",
+      "src": "../missing_480.png",
       "sizes": "480",
       "type": "image/png",
       "density": 1

--- a/web_no_meta_viewport/index.html
+++ b/web_no_meta_viewport/index.html
@@ -3,11 +3,10 @@
 <head>
   <script src="index.js"></script>
   <link rel="manifest" href="manifest.json">
-  <!-- <meta name="viewport" content="width=device-width, initial-scale=1"> -->
 </head>
 <body>
   <h1>Marmots are the best.</h1>
-  <p>Site which is a valid web app. v12.</p>
+  <p>Site which is missing a viewport.</p>
   <div id="logs"></div>
 </body>
 </html>

--- a/web_redispatch/index.html
+++ b/web_redispatch/index.html
@@ -7,6 +7,6 @@
 </head>
 <body>
   <h1>Marmots are the best.</h1>
-  <p>Site which is a valid web app. v12.</p>
+  <p>Site which is a valid web app.</p>
 </body>
 </html>


### PR DESCRIPTION
This fixes a number of minor issues among all the apps:

- Added missing `viewport` tags to web apps.
- Removed version numbers from description paragraphs.
- Fixed incorrect app descriptions.
- Removed `id` from iOS `related_applications`; replaced with a plausible `url` field.
- Added some missing Manifest fields (e.g., `prefer_related_applications`, `display`).
- Added all icon sizes for web apps.
- web_broken: Use an obviously "missing" icon filename.