### PR TITLE
Update links to the App Engine site

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 This is a demo of the [Web App Manifest](https://w3c.github.io/manifest) spec.
 
-[Live Demo](https://benfredwells.github.io/killer-marmot).
+[Live Demo](https://killer-marmot.appspot.com).

--- a/android_app/README.md
+++ b/android_app/README.md
@@ -2,5 +2,5 @@
 
 This app is used to test the `getInstalledRelatedApps` API on Android. The app
 does nothing, but its manifest links to
-[https://benfredwells.github.io](https://benfredwells.github.io), so if
+[https://killer-marmot.appspot.com](https://killer-marmot.appspot.com), so if
 installed, it will register as a related app from that site.

--- a/android_app/app/src/main/res/values/strings.xml
+++ b/android_app/app/src/main/res/values/strings.xml
@@ -7,6 +7,12 @@
           \"namespace\": \"web\",
           \"site\": \"https://benfredwells.github.io\"
         }
+      }, {
+        \"relation\": [\"delegate_permission/common.share_location\"],
+        \"target\": {
+          \"namespace\": \"web\",
+          \"site\": \"https://killer-marmot.appspot.com\"
+        }
       }]
     </string>
 </resources>


### PR DESCRIPTION
Updates links from README files as well as the Digital Asset Links in the Android app.

The Android app now points at both the old and new locations.