### PR TITLE
Add ability for user to create new Marmot apps with custom manifest

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -4,6 +4,10 @@ threadsafe: true
 
 handlers:
 # These files are the same for each app.
+- url: /custom/[A-Za-z0-9\-_=]*/([^/]*\.(css|js|png|svg))
+  static_files: static/\1
+  upload: static/[^/]*\.(css|js|png|svg)
+  secure: always
 - url: /[a-z_]*/([^/]*\.(css|js|png|svg))
   static_files: static/\1
   upload: static/[^/]*\.(css|js|png|svg)
@@ -11,6 +15,10 @@ handlers:
 
 # Main index page.
 - url: /
+  script: main.app
+  secure: always
+# Custom pages.
+- url: /custom/([A-Za-z0-9\-_=]*)(/(|manifest\.json))?
   script: main.app
   secure: always
 # The other files are templated, changing based on the directory name.

--- a/custom.py
+++ b/custom.py
@@ -53,6 +53,10 @@ def build_custom_manifest(b64manifest):
     except ValueError:
       return 400, 'Invalid JSON for manifest.'
 
+    # Insert default icons if none included.
+    if 'icons' not in manifest:
+      manifest['icons'] = app_data.DEFAULT_ICONS
+
     # TODO: Basic validation.
 
     # Re-encode JSON so that it is formatted nicely.

--- a/custom.py
+++ b/custom.py
@@ -61,7 +61,10 @@ def build_custom_manifest(b64manifest, insert_icons=False):
     if insert_icons and 'icons' not in manifest:
       manifest['icons'] = app_data.DEFAULT_ICONS
 
-    # TODO: Basic validation.
+    # Basic validation to make sure a user can't create a URL that runs unknown
+    # code, then send the link to other users.
+    if 'serviceworker' in manifest:
+      return 400, 'Custom manifest cannot have "serviceworker".'
 
     # Re-encode JSON so that it is formatted nicely.
     return 200, json.dumps(manifest, indent=2, separators=(',', ': ')) + '\n'

--- a/custom.py
+++ b/custom.py
@@ -1,0 +1,59 @@
+# Copyright 2018 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import app_data
+import base64
+import json
+
+
+def get_template_params():
+    """Get the template parameters for a custom app page."""
+    params = app_data.APPS['web'].copy()
+    params['viewport'] = app_data.DEFAULT_VIEWPORT
+    params['description'] = 'The manifest is customized via the URL.'
+    params['short_description'] = 'Custom app'
+    return params
+
+
+def build_custom_manifest(b64manifest):
+    """Creates a manifest from a URL-safe-base-64-encoded manifest string.
+
+    Returns (HTTP status code, body).
+    """
+    # Decode from URL-safe-base-64 to UTF-8 bytes.
+    try:
+      manifest_original_bytes = base64.urlsafe_b64decode(b64manifest)
+    except TypeError:
+      return 400, 'Invalid base-64-encoded manifest.'
+
+    # Decode from UTF-8 bytes to JSON string.
+    try:
+      manifest_original = manifest_original_bytes.decode('utf-8')
+    except UnicodeDecodeError:
+      return 400, 'Invalid UTF-8-encoded manifest.'
+
+    # Parse JSON string as JSON object.
+    try:
+      manifest = json.loads(manifest_original)
+    except ValueError:
+      return 400, 'Invalid JSON for manifest.'
+
+    # TODO: Basic validation.
+
+    # Re-encode JSON so that it is formatted nicely.
+    return 200, json.dumps(manifest, indent=2, separators=(',', ': ')) + '\n'

--- a/custom.py
+++ b/custom.py
@@ -61,3 +61,13 @@ def build_custom_manifest(b64manifest):
 
     # Re-encode JSON so that it is formatted nicely.
     return 200, json.dumps(manifest, indent=2, separators=(',', ': ')) + '\n'
+
+
+def encode_manifest(manifest_string):
+    """Creates a URL-safe-base-64-encoded manifest string from a full manifest.
+
+    Raises a ValueError if the string is not valid JSON.
+    """
+    manifest = json.loads(manifest_string)
+    manifest_minified = json.dumps(manifest)
+    return base64.urlsafe_b64encode(manifest_minified)

--- a/custom.py
+++ b/custom.py
@@ -16,6 +16,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import collections
+
 import app_data
 import base64
 import json
@@ -49,7 +51,8 @@ def build_custom_manifest(b64manifest):
 
     # Parse JSON string as JSON object.
     try:
-      manifest = json.loads(manifest_original)
+      manifest = json.loads(manifest_original,
+                            object_pairs_hook=collections.OrderedDict)
     except ValueError:
       return 400, 'Invalid JSON for manifest.'
 
@@ -68,6 +71,7 @@ def encode_manifest(manifest_string):
 
     Raises a ValueError if the string is not valid JSON.
     """
-    manifest = json.loads(manifest_string)
+    manifest = json.loads(manifest_string,
+                          object_pairs_hook=collections.OrderedDict)
     manifest_minified = json.dumps(manifest)
     return base64.urlsafe_b64encode(manifest_minified)

--- a/custom.py
+++ b/custom.py
@@ -23,16 +23,17 @@ import base64
 import json
 
 
-def get_template_params():
+def get_template_params(manifest_string):
     """Get the template parameters for a custom app page."""
     params = app_data.APPS['web'].copy()
     params['viewport'] = app_data.DEFAULT_VIEWPORT
     params['description'] = 'The manifest is customized via the URL.'
     params['short_description'] = 'Custom app'
+    params['custom_manifest'] = manifest_string
     return params
 
 
-def build_custom_manifest(b64manifest):
+def build_custom_manifest(b64manifest, insert_icons=False):
     """Creates a manifest from a URL-safe-base-64-encoded manifest string.
 
     Returns (HTTP status code, body).
@@ -57,7 +58,7 @@ def build_custom_manifest(b64manifest):
       return 400, 'Invalid JSON for manifest.'
 
     # Insert default icons if none included.
-    if 'icons' not in manifest:
+    if insert_icons and 'icons' not in manifest:
       manifest['icons'] = app_data.DEFAULT_ICONS
 
     # TODO: Basic validation.

--- a/main.py
+++ b/main.py
@@ -162,6 +162,7 @@ class CustomApp(webapp2.RequestHandler):
 
 app = webapp2.WSGIApplication([
     (r'/$', IndexPage),
+    (r'/custom/[A-Za-z0-9\-_=]*', IndexRedirect),
     (r'/[^/]*$', IndexRedirect),
     (r'/custom/([A-Za-z0-9\-_=]*)/([^/]*)', CustomApp),
     (r'/([^/]*)/([^/]*)', TemplatedPage),

--- a/main.py
+++ b/main.py
@@ -148,7 +148,8 @@ class CustomApp(webapp2.RequestHandler):
         self.response.content_type_params = {'charset': 'utf-8'}
 
         if filename == 'manifest.json':
-            status, response_body = custom.build_custom_manifest(b64manifest)
+            status, response_body = \
+                custom.build_custom_manifest(b64manifest, insert_icons=True)
             self.response.status = status
         else:
             status, manifest_string = custom.build_custom_manifest(b64manifest)
@@ -162,7 +163,7 @@ class CustomApp(webapp2.RequestHandler):
 
                 template_params = {}
                 if filename == 'app.html':
-                  template_params = custom.get_template_params()
+                  template_params = custom.get_template_params(manifest_string)
 
                 response_body = template.render(template_params)
         self.response.write(response_body)
@@ -177,6 +178,10 @@ class CreateCustom(webapp2.RequestHandler):
     def get(self):
         # Just get the default manifest ("web").
         manifest_string = build_manifest('web', set_icons=False)
+        self.redirect_using_manifest(manifest_string)
+
+    def post(self):
+        manifest_string = self.request.POST['manifest']
         self.redirect_using_manifest(manifest_string)
 
     def redirect_using_manifest(self, manifest_string):

--- a/main.py
+++ b/main.py
@@ -151,13 +151,20 @@ class CustomApp(webapp2.RequestHandler):
             status, response_body = custom.build_custom_manifest(b64manifest)
             self.response.status = status
         else:
-            template = env.get_template(filename)
+            status, manifest_string = custom.build_custom_manifest(b64manifest)
+            self.response.status = status
 
-            template_params = {}
-            if filename == 'app.html':
-              template_params = custom.get_template_params()
+            if status != 200:
+                # Just show the error message.
+                response_body = manifest_string
+            else:
+                template = env.get_template(filename)
 
-            response_body = template.render(template_params)
+                template_params = {}
+                if filename == 'app.html':
+                  template_params = custom.get_template_params()
+
+                response_body = template.render(template_params)
         self.response.write(response_body)
 
 

--- a/main.py
+++ b/main.py
@@ -90,6 +90,8 @@ class IndexPage(webapp2.RequestHandler):
         self.response.content_type_params = {'charset': 'utf-8'}
         template = env.get_template('index.html')
         app_list = list(get_app_list())
+        app_list.append({'name': 'custom',
+                         'description': 'App with custom manifest'})
         response_body = template.render({'apps': app_list})
         self.response.write(response_body)
 

--- a/main.py
+++ b/main.py
@@ -98,7 +98,7 @@ class IndexRedirect(webapp2.RequestHandler):
     Redirect by adding a '/' to the end of the URL (so that relative links are
     correct).
     """
-    def get(self, appname):
+    def get(self):
         self.response.status = 301
         self.response.location = self.request.uri + '/'
 
@@ -162,7 +162,7 @@ class CustomApp(webapp2.RequestHandler):
 
 app = webapp2.WSGIApplication([
     (r'/$', IndexPage),
-    (r'/([^/]*)$', IndexRedirect),
+    (r'/[^/]*$', IndexRedirect),
     (r'/custom/([A-Za-z0-9\-_=]*)/([^/]*)', CustomApp),
     (r'/([^/]*)/([^/]*)', TemplatedPage),
 ], debug=True)

--- a/templates/app.html
+++ b/templates/app.html
@@ -24,6 +24,18 @@
       Web Apps</a>.
     {{ description }}
   </p>
+  {% if custom_manifest %}
+  <div class="log-section">
+    <h2>Manifest</h2>
+    <form action="/custom/" method="post">
+      <p>This app has the following custom manifest:</p>
+      <textarea cols="80" rows="20" name="manifest">{{custom_manifest}}</textarea>
+      <p>Editing the manifest will create a new custom app and redirect to
+      it. The app has the default icons unless new icons are specified.</p>
+      <p><input type="submit" value="Update" /></p>
+    </form>
+  </div>
+  {% endif %}
   {% if index_js %}<div id="logs"></div>{% endif %}
   <p>
     <a href="/">Home</a>


### PR DESCRIPTION
The custom manifest is base-64-encoded in the app's URL, so no state is stored on the server. Custom app URLs can be bookmarked/shared. Includes UI for creating and editing the custom app's manifest.