### PR TITLE
Add custom control over BeforeInstallPrompt handler

### DIFF
--- a/static/index.js
+++ b/static/index.js
@@ -35,14 +35,6 @@ function createLogSection(title) {
 }
 
 async function logUserChoice(section, e) {
-  section.logMessage('userChoice is: ' + e.userChoice);
-  await sleep(1000);
-  if (!e) {
-    section.logMessage('No event????', true);
-    return;
-  }
-
-  section.logMessage('Timer time!');
   try {
     let {platform, outcome} = await e.userChoice;
     section.logMessage('platform is: \'' + platform + '\'');
@@ -73,6 +65,8 @@ window.addEventListener('beforeinstallprompt', async e => {
   }
 
   logs.logMessage('No, let\'s see the banner');
+  await sleep(1000);
+  logs.logMessage('Timer time!');
   logUserChoice(logs, e);
 });
 

--- a/static/index.js
+++ b/static/index.js
@@ -46,6 +46,12 @@ QUERY_PARAMS = {};
 {
   for (const [n, v] of new URL(document.location).searchParams)
     QUERY_PARAMS[n] = v;
+
+  // Set defaults.
+  if (!QUERY_PARAMS.action)
+    QUERY_PARAMS.action = 'manual';
+  if (!QUERY_PARAMS.timer)
+    QUERY_PARAMS.timer = 0;
 }
 
 window.addEventListener('beforeinstallprompt', async e => {
@@ -54,8 +60,8 @@ window.addEventListener('beforeinstallprompt', async e => {
       'Got beforeinstallprompt! {platforms: ' + JSON.stringify(e.platforms) +
       '}');
 
-  const action = QUERY_PARAMS.action || 'manual';
-  const timer = QUERY_PARAMS.timer || 0;
+  const action = QUERY_PARAMS.action;
+  const timer = QUERY_PARAMS.timer;
 
   if (action !== 'none') {
     logs.logMessage('Calling preventDefault().');
@@ -132,4 +138,7 @@ window.addEventListener('load', e => {
   if (document.location.hash == '#cameBack') {
     document.querySelector('#cameback').style.display = 'block';
   }
+
+  document.querySelector('#bip_' + QUERY_PARAMS.action).checked = true;
+  document.querySelector('#bip_timer').value = QUERY_PARAMS.timer;
 });

--- a/static/index.js
+++ b/static/index.js
@@ -34,6 +34,13 @@ function createLogSection(title) {
   return new LogSection(document.querySelector('#logs'), title);
 }
 
+// Get the current document's query parameters.
+QUERY_PARAMS = {};
+{
+  for (const [n, v] of new URL(document.location).searchParams)
+    QUERY_PARAMS[n] = v;
+}
+
 async function logUserChoice(section, e) {
   try {
     let {platform, outcome} = await e.userChoice;
@@ -48,9 +55,10 @@ window.addEventListener('beforeinstallprompt', async e => {
   let logs = createLogSection('beforeinstallprompt');
   logs.logMessage('Got beforeinstallprompt!!!');
   logs.logMessage('platforms: ' + e.platforms);
+  const timer = QUERY_PARAMS.timer;
   logs.logMessage('Should I cancel it? Hmmmm .... ');
 
-  if (Math.random() > 0.5) {
+  if (timer === undefined) {
     logs.logMessage('Yeah why not. Cancelled!');
     e.preventDefault();
     await logs.logClickableLink('Show the prompt after all.');
@@ -64,9 +72,15 @@ window.addEventListener('beforeinstallprompt', async e => {
     return;
   }
 
-  logs.logMessage('No, let\'s see the banner');
-  await sleep(1000);
-  logs.logMessage('Timer time!');
+  if (timer > 0) {
+    logs.logMessage(
+        'No, let\'s see the banner in ' + timer +
+        ' shakes of a marmot\'s tail.');
+    await sleep(timer * 1000);
+    logs.logMessage('Timer time!');
+  } else {
+    logs.logMessage('No, let\'s see the banner NOW.');
+  }
   logUserChoice(logs, e);
 });
 

--- a/static/index.js
+++ b/static/index.js
@@ -52,7 +52,7 @@ QUERY_PARAMS = {};
   if (!QUERY_PARAMS.action)
     QUERY_PARAMS.action = 'manual';
   if (!QUERY_PARAMS.timer)
-    QUERY_PARAMS.timer = 0;
+    QUERY_PARAMS.timer = 1;
 }
 
 window.addEventListener('beforeinstallprompt', async e => {

--- a/static/index.js
+++ b/static/index.js
@@ -36,13 +36,15 @@ function createLogSection(title) {
 
 // Get the current document's query parameters.
 // Expected query parameters:
-// - action={'none', 'cancel', 'auto', 'manual'}: beforeinstallprompt behavior.
+// - action={'none', 'cancel', 'preempt', 'auto', 'manual'}: beforeinstallprompt
+//          behavior.
 //     none: do nothing.
 //     cancel: call preventDefault().
+//     preempt: call prompt() without preventDefault().
 //     auto: call preventDefault(), wait, then call prompt().
 //     manual (default): call preventDefault(), then add a button which calls
 //         prompt().
-// - timer=<int>: time to wait in seconds, if action is 'auto'.
+// - timer=<int>: time to wait in seconds, if action is 'preempt' or 'auto'.
 QUERY_PARAMS = {};
 {
   for (const [n, v] of new URL(document.location).searchParams)
@@ -76,8 +78,8 @@ window.addEventListener('beforeinstallprompt', async e => {
     await sleep(timer * 1000);
   }
 
-  if (action === 'auto' || action === 'manual') {
-    if (action === 'auto')
+  if (action === 'preempt' || action === 'auto' || action === 'manual') {
+    if (action !== 'manual')
       logs.logMessage('Explicitly calling prompt().');
     try {
       const r = await e.prompt();

--- a/static/index.js
+++ b/static/index.js
@@ -37,11 +37,12 @@ function createLogSection(title) {
 // Get the current document's query parameters.
 // Expected query parameters:
 // - action={'none', 'cancel', 'auto', 'manual'}: beforeinstallprompt behavior.
-//     none: wait, then do nothing.
-//     cancel: cancel event, wait, then do nothing.
-//     auto: cancel event, wait, then call prompt().
-//     manual (default): cancel event, then add a button which calls prompt().
-// - timer=<int>: time to wait in seconds, if action is not 'manual'.
+//     none: do nothing.
+//     cancel: call preventDefault().
+//     auto: call preventDefault(), wait, then call prompt().
+//     manual (default): call preventDefault(), then add a button which calls
+//         prompt().
+// - timer=<int>: time to wait in seconds, if action is 'auto'.
 QUERY_PARAMS = {};
 {
   for (const [n, v] of new URL(document.location).searchParams)
@@ -63,14 +64,14 @@ window.addEventListener('beforeinstallprompt', async e => {
   const action = QUERY_PARAMS.action;
   const timer = QUERY_PARAMS.timer;
 
-  if (action !== 'none') {
+  if (action !== 'none' && action !== 'preempt') {
     logs.logMessage('Calling preventDefault().');
     e.preventDefault();
   }
 
   if (action === 'manual') {
     await logs.logClickableLink('Show the prompt after all.');
-  } else if (timer > 0) {
+  } else if (action === 'auto' && timer > 0) {
     logs.logMessage(`Sleeping for ${timer} second${timer == '1' ? '' : 's'}.`);
     await sleep(timer * 1000);
   }

--- a/templates/app.html
+++ b/templates/app.html
@@ -56,13 +56,13 @@
     <form method="GET">
       <p>
         <input type="radio" name="action" id="bip_none" value="none">
-        <label for="bip_none">None (wait, then do nothing).</label><br>
+        <label for="bip_none">None (do nothing).</label><br>
         <input type="radio" name="action" id="bip_cancel" value="cancel">
-        <label for="bip_cancel">Cancel (cancel event, wait, then do nothing).</label><br>
+        <label for="bip_cancel">Cancel (call preventDefault).</label><br>
         <input type="radio" name="action" id="bip_auto" value="auto">
-        <label for="bip_auto">Auto (cancel event, wait, then call prompt()).</label><br>
+        <label for="bip_auto">Auto (call preventDefault, wait, then call prompt).</label><br>
         <input type="radio" name="action" id="bip_manual" value="manual">
-        <label for="bip_manual">Manual (cancel event, then add a button which calls prompt()).</label><br>
+        <label for="bip_manual">Manual (call preventDefault, then add a button which calls prompt).</label><br>
       </p>
       <p>Timer: <input name="timer" id="bip_timer" size="1" /> seconds</p>
       <p><input type="submit" value="Try it" /></p>

--- a/templates/app.html
+++ b/templates/app.html
@@ -50,6 +50,23 @@
       </form>
     </p>
     <p id="cameback" style="display: none">I see you're back!</p>
+  </div>
+  <div class="log-section">
+    <h2>Custom beforeinstallprompt behavior</h2>
+    <form method="GET">
+      <p>
+        <input type="radio" name="action" id="bip_none" value="none">
+        <label for="bip_none">None (wait, then do nothing).</label><br>
+        <input type="radio" name="action" id="bip_cancel" value="cancel">
+        <label for="bip_cancel">Cancel (cancel event, wait, then do nothing).</label><br>
+        <input type="radio" name="action" id="bip_auto" value="auto">
+        <label for="bip_auto">Auto (cancel event, wait, then call prompt()).</label><br>
+        <input type="radio" name="action" id="bip_manual" value="manual">
+        <label for="bip_manual">Manual (cancel event, then add a button which calls prompt()).</label><br>
+      </p>
+      <p>Timer: <input name="timer" id="bip_timer" size="1" /> seconds</p>
+      <p><input type="submit" value="Try it" /></p>
+    </form>
   </div>{% endif %}
   <p>
     <a href="/">Home</a>

--- a/templates/app.html
+++ b/templates/app.html
@@ -59,6 +59,8 @@
         <label for="bip_none">None (do nothing).</label><br>
         <input type="radio" name="action" id="bip_cancel" value="cancel">
         <label for="bip_cancel">Cancel (call preventDefault).</label><br>
+        <input type="radio" name="action" id="bip_preempt" value="preempt">
+        <label for="bip_preempt">Pre-empt (call prompt without preventDefault).</label><br>
         <input type="radio" name="action" id="bip_auto" value="auto">
         <label for="bip_auto">Auto (call preventDefault, wait, then call prompt).</label><br>
         <input type="radio" name="action" id="bip_manual" value="manual">


### PR DESCRIPTION
Adds UI for controlling this, rather than just having a 50/50 chance to cancel or not.

User can now specify one of four options:

- None (do nothing).
- Cancel (call `preventDefault`).
- Pre-empt (call `prompt` without `preventDefault`).
- Auto (call `preventDefault`, wait, then call `prompt`).
- Manual (call `preventDefault`, then add a button which calls `prompt`).

Manual is the default (the only one that actually works on Chrome). You can also specify how long the timer runs for, in the "auto" case.

Also cleaned up the logging strings.