### PR TITLE
Updates badging origin trial tokens for launch in M73

### DIFF
--- a/templates/app.html
+++ b/templates/app.html
@@ -11,7 +11,10 @@
   <title>Killer Marmot: {{ short_explanation }}</title>
   <!-- Origin Trial Token, feature = getInstalledRelatedApps, origin = https://killer-marmot.appspot.com, expires = 2017-10-02 -->
   <meta http-equiv="origin-trial" data-feature="getInstalledRelatedApps" data-expires="2017-10-02" content="Asx0ImrLjVZ+vCVuW82Qv3VwafGfpV4gOjw2qUsfWHVZ5vk/6pxSX+h5jIPTzxc5KeLBSZtRkckTCKeRK8+yOgUAAABfeyJvcmlnaW4iOiJodHRwczovL2tpbGxlci1tYXJtb3QuYXBwc3BvdC5jb206NDQzIiwiZmVhdHVyZSI6Ikluc3RhbGxlZEFwcCIsImV4cGlyeSI6MTUwNjkxNTgxNH0=">
-  <meta http-equiv="origin-trial" data-feature="badging" data-expires="2019-03-06" content="AmyTX2Vd6c2SmVbendI+N+MY4Vo/8bf8Xwsj8GUrxv2fF7J7DnOZa6IoQeh6Ng9Z0hZ5G21ATwp40GHY70YpNg4AAABaeyJvcmlnaW4iOiJodHRwczovL2tpbGxlci1tYXJtb3QuYXBwc3BvdC5jb206NDQzIiwiZmVhdHVyZSI6IkJhZGdpbmciLCJleHBpcnkiOjE1NTE4MjQyMjJ9">
+  <!-- Origin Trial Token (for development), feature = Badging, origin = localhost:8080, expires = 2019-04-17 -->
+  <meta http-equiv="origin-trial" data-feature="badging" data-expires="2019-04-17" content="ApB1CHJ0SWUphDj1uaAlS3j7s9FIHosNn8JLdgwcpY4DF63fEvM7C31k8pt7Gk8Y+HinNRANVkchG2R5frooXAsAAABKeyJvcmlnaW4iOiJodHRwOi8vbG9jYWxob3N0OjgwODAiLCJmZWF0dXJlIjoiQmFkZ2luZyIsImV4cGlyeSI6MTU1NTQ1NDkzOX0=">
+  <!-- Origin Trial Token, feature = Badging, origin = killer-marmot.appspot.com, expires = 2019-04-17 -->
+  <meta http-equiv="origin-trial" data-feature="badging" data-expires="2019-04-17" content="ApKuhxTsU1tiGYBwSCsA2FENXPZjqTOZP9Z9LqjXzp+fctd7CdtoaCzjjR64z0PeRHcSyBgPnQRCEvC25gYQHA0AAABaeyJvcmlnaW4iOiJodHRwczovL2tpbGxlci1tYXJtb3QuYXBwc3BvdC5jb206NDQzIiwiZmVhdHVyZSI6IkJhZGdpbmciLCJleHBpcnkiOjE1NTU0NTQ4MjJ9">
 </head>
 <body>
   <div class="quote">


### PR DESCRIPTION
The Badging Origin Trial Token expired. This updates it and adds a separate token for localhost development.