### PR TITLE
Update to use the new Badge API in Chrome 79

### DIFF
--- a/static/index.js
+++ b/static/index.js
@@ -149,12 +149,11 @@ window.addEventListener('load', e => {
   setupNavigationSection();
 });
 
-function setBadge() {
-  console.log(arguments);
+function setBadge(...args) {
   if (navigator.setExperimentalAppBadge)
-    navigator.setExperimentalAppBadge.apply(navigator, arguments);
+    navigator.setExperimentalAppBadge.apply(navigator, args);
   else if (window.ExperimentalBadge)
-    ExperimentalBadge.set.apply(null, arguments);
+    ExperimentalBadge.set.apply(null, args);
 }
 
 function clearBadge() {

--- a/static/index.js
+++ b/static/index.js
@@ -149,13 +149,30 @@ window.addEventListener('load', e => {
   setupNavigationSection();
 });
 
+function setBadge() {
+  console.log(arguments);
+  if (navigator.setExperimentalAppBadge)
+    navigator.setExperimentalAppBadge.apply(navigator, arguments);
+  else if (window.ExperimentalBadge)
+    ExperimentalBadge.set.apply(null, arguments);
+}
+
+function clearBadge() {
+  if (navigator.clearExperimentalAppBadge)
+    navigator.clearExperimentalAppBadge();
+  else if (window.ExperimentalBadge)
+    ExperimentalBadge.clear();
+}
+
+function badgeAPIAvailable() {
+  return !!(navigator.setExperimentalAppBadge || window.ExperimentalBadge);
+}
+
 const setupBadgeSection = () => {
   const logs = new LogSection(document.querySelector('#badge_section'));
-  const badgeAPI = window.Badge || window.ExperimentalBadge;
-
-  // Check that the API is available.
-  if (!badgeAPI) {
-    logs.logMessage("Badge and ExperimentalBadge are undefined.");
+  if (!badgeAPIAvailable) {
+    logs.logMessage("navigator.setExperimentalAppBadge and ExperimentalBadge "
+                    + "(deprecated) are undefined.");
     document.querySelector('#badge_section_contents').remove();
     return;
   }
@@ -165,16 +182,16 @@ const setupBadgeSection = () => {
     const badgeContent = document.querySelector('#badge_content').value;
     // If the badge content is empty set a flag.
     if (badgeContent === '') {
-      badgeAPI.set();
+      setBadge();
     }
     // Otherwise, set the badge to our badge content.
     else {
-      badgeAPI.set(badgeContent);
+      setBadge(badgeContent);
     }
   });
 
   const clearBadgeButton = document.querySelector('#clear_badge');
-  clearBadgeButton.addEventListener('click', badgeAPI.clear);
+  clearBadgeButton.addEventListener('click', clearBadge);
 };
 
 const setupNavigationSection = () => {

--- a/static/index.js
+++ b/static/index.js
@@ -163,9 +163,8 @@ function clearBadge() {
     ExperimentalBadge.clear();
 }
 
-function badgeAPIAvailable() {
-  return !!(navigator.setExperimentalAppBadge || window.ExperimentalBadge);
-}
+const badgeAPIAvailable =
+    !!(navigator.setExperimentalAppBadge || window.ExperimentalBadge);
 
 const setupBadgeSection = () => {
   const logs = new LogSection(document.querySelector('#badge_section'));

--- a/static/index.js
+++ b/static/index.js
@@ -151,9 +151,9 @@ window.addEventListener('load', e => {
 
 function setBadge(...args) {
   if (navigator.setExperimentalAppBadge)
-    navigator.setExperimentalAppBadge.apply(navigator, args);
+    navigator.setExperimentalAppBadge(...args);
   else if (window.ExperimentalBadge)
-    ExperimentalBadge.set.apply(null, args);
+    ExperimentalBadge.set(...args);
 }
 
 function clearBadge() {

--- a/static/index.js
+++ b/static/index.js
@@ -150,18 +150,13 @@ window.addEventListener('load', e => {
 });
 
 const setupBadgeSection = () => {
-  const badgeSection = document.querySelector('#badge_section');
+  const logs = new LogSection(document.querySelector('#badge_section'));
   const badgeAPI = window.Badge || window.ExperimentalBadge;
 
-  if (!badgeSection) {
-    return;
-  }
   // Check that the API is available.
   if (!badgeAPI) {
-    console.log("Badge API not detected :'(");
-
-    // If the Badging API is not available, hide the section.
-    badgeSection.remove();
+    logs.logMessage("Badge and ExperimentalBadge are undefined.");
+    document.querySelector('#badge_section_contents').remove();
     return;
   }
 

--- a/static/logging.js
+++ b/static/logging.js
@@ -14,7 +14,14 @@
 
 class LogSection {
   // Creates a new <div> for logs relating to a particular function.
+  // If logsDiv is an existing log-section class, just creates a LogSection
+  // object for that existing <div>, rather than creating a new <div>.
   constructor(logsDiv, title) {
+    if (logsDiv.classList.contains('log-section')) {
+      this.div = logsDiv;
+      return;
+    }
+
     this.div = document.createElement('div');
     logsDiv.appendChild(this.div);
     this.div.className = 'log-section';

--- a/templates/app.html
+++ b/templates/app.html
@@ -10,6 +10,8 @@
   {% if viewport %}<meta name="viewport" content="{{ viewport }}">{% endif %}
   {% if referrer %}<meta name="referrer" content="origin">{% endif %}
   <title>Killer Marmot: {{ short_explanation }}</title>
+  <!-- Origin Trial Token, feature = Badging, origin = https://killer-marmot.appspot.com, expires = 2019-11-19 -->
+  <meta http-equiv="origin-trial" content="AvIbIc1X+47sUj5/Cf478E4Bl8Ky6bqKKM9UUUrUr01gzo/bOXva17vDW3VUAW4yK3gArzEc57Us0SZ1evae5gMAAABaeyJvcmlnaW4iOiJodHRwczovL2tpbGxlci1tYXJtb3QuYXBwc3BvdC5jb206NDQzIiwiZmVhdHVyZSI6IkJhZGdpbmciLCJleHBpcnkiOjE1NzQ5ODU2MTV9">
   <!-- Origin Trial Token, feature = Badging V2, origin = https://killer-marmot.appspot.com, expires = 2019-10-31 -->
   <meta http-equiv="origin-trial" content="As3qw04y4DJnNYawPKeXHM9T/Is5KjW3X+VhsN2yRf4V9CApX2NIhvxVHyi0Pwk59Yc0A8Bxlos67eNO1H+dbwwAAABceyJvcmlnaW4iOiJodHRwczovL2tpbGxlci1tYXJtb3QuYXBwc3BvdC5jb206NDQzIiwiZmVhdHVyZSI6IkJhZGdpbmdWMiIsImV4cGlyeSI6MTU3MjQ4Njc1N30=">
 </head>

--- a/templates/app.html
+++ b/templates/app.html
@@ -10,10 +10,10 @@
   {% if viewport %}<meta name="viewport" content="{{ viewport }}">{% endif %}
   {% if referrer %}<meta name="referrer" content="origin">{% endif %}
   <title>Killer Marmot: {{ short_explanation }}</title>
-  <!-- Origin Trial Token, feature = Badging, origin = https://killer-marmot.appspot.com, expires = 2019-11-19 -->
-  <meta http-equiv="origin-trial" content="AvIbIc1X+47sUj5/Cf478E4Bl8Ky6bqKKM9UUUrUr01gzo/bOXva17vDW3VUAW4yK3gArzEc57Us0SZ1evae5gMAAABaeyJvcmlnaW4iOiJodHRwczovL2tpbGxlci1tYXJtb3QuYXBwc3BvdC5jb206NDQzIiwiZmVhdHVyZSI6IkJhZGdpbmciLCJleHBpcnkiOjE1NzQ5ODU2MTV9">
-  <!-- Origin Trial Token, feature = Badging V2, origin = https://killer-marmot.appspot.com, expires = 2019-10-31 -->
-  <meta http-equiv="origin-trial" content="As3qw04y4DJnNYawPKeXHM9T/Is5KjW3X+VhsN2yRf4V9CApX2NIhvxVHyi0Pwk59Yc0A8Bxlos67eNO1H+dbwwAAABceyJvcmlnaW4iOiJodHRwczovL2tpbGxlci1tYXJtb3QuYXBwc3BvdC5jb206NDQzIiwiZmVhdHVyZSI6IkJhZGdpbmdWMiIsImV4cGlyeSI6MTU3MjQ4Njc1N30=">
+  <!-- Origin Trial Token, feature = Badging, origin = https://killer-marmot.appspot.com, expires = 2019-12-04 -->
+  <meta http-equiv="origin-trial" content="ArdlIIOjDvqzGuoUlmOnD61Ep8bE9HFOQ8D9j/wIlQidGmDGmJADnEHeXT0Bo+wLNnOWeFsGO336HonSvn3ZcAQAAABaeyJvcmlnaW4iOiJodHRwczovL2tpbGxlci1tYXJtb3QuYXBwc3BvdC5jb206NDQzIiwiZmVhdHVyZSI6IkJhZGdpbmciLCJleHBpcnkiOjE1NzU0MTc1OTl9">
+  <!-- Origin Trial Token, feature = Badging V2, origin = https://killer-marmot.appspot.com, expires = 2019-12-13 -->
+  <meta http-equiv="origin-trial" content="Auksq5kSoX8H/kF9Z4k/vD340L6qHPFrb9BMLVqQ4ru2cqZ4VDNE6Nn5vFwhZkG1fzEDDOaFxq6Q8QO89cBm7AQAAABceyJvcmlnaW4iOiJodHRwczovL2tpbGxlci1tYXJtb3QuYXBwc3BvdC5jb206NDQzIiwiZmVhdHVyZSI6IkJhZGdpbmdWMiIsImV4cGlyeSI6MTU3NjE5MjU1M30=">
 </head>
 <body>
   <div class="quote">

--- a/templates/app.html
+++ b/templates/app.html
@@ -70,16 +70,17 @@
       <p>Timer: <input name="timer" id="bip_timer" size="1" /> seconds</p>
       <p><input type="submit" value="Try it" /></p>
     </form>
-  </div>{% endif %}
-  {% if index_js %}<div class="log-section hide-in-browser" id="badge_section">
-    <h2>Badging: Set/Clear the PWA's badge.</h2>
-    <p><input name="badge" id="badge_content" size="1"/> <button id="set_badge">Set Badge</button></p>
-    <p><button id="clear_badge">Clear Badge</button></p>
-    <a href="https://github.com/WICG/badging/blob/master/explainer.md">Explanation of Badging</a>
-    <p>Note: this will only work if the PWA is installed and running in a window.</p>
+  </div>
+  <div class="log-section" id="badge_section">
+    <h2>Badging</h2>
+    <div id="badge_section_contents">
+      <p><input name="badge" id="badge_content" size="1"/> <button id="set_badge">Set Badge</button></p>
+      <p><button id="clear_badge">Clear Badge</button></p>
+      <a href="https://github.com/WICG/badging/blob/master/explainer.md">Explanation of Badging</a>
+    </div>
   </div>
   <div class="log-section hide-in-browser" id="navigation_section">
-    <h2>Navigation Tests.</h2>
+    <h2>Navigation tests</h2>
     <p><input name="navigate" id="navigate_url" size="20" type="text"/> <button id="navigate_button">Navigate</button></p>
     <p>This should be used to test how PWAs work when navigating to other sites.</p>
   </div>

--- a/templates/app.html
+++ b/templates/app.html
@@ -1,6 +1,10 @@
 <!doctype html>
 <html>
 <head>
+  <!-- Origin Trial Token, feature = Badging, origin = https://killer-marmot.appspot.com, expires = 2019-12-04 -->
+  <meta http-equiv="origin-trial" content="ArdlIIOjDvqzGuoUlmOnD61Ep8bE9HFOQ8D9j/wIlQidGmDGmJADnEHeXT0Bo+wLNnOWeFsGO336HonSvn3ZcAQAAABaeyJvcmlnaW4iOiJodHRwczovL2tpbGxlci1tYXJtb3QuYXBwc3BvdC5jb206NDQzIiwiZmVhdHVyZSI6IkJhZGdpbmciLCJleHBpcnkiOjE1NzU0MTc1OTl9">
+  <!-- Origin Trial Token, feature = Badging V2, origin = https://killer-marmot.appspot.com, expires = 2019-12-13 -->
+  <meta http-equiv="origin-trial" content="Auksq5kSoX8H/kF9Z4k/vD340L6qHPFrb9BMLVqQ4ru2cqZ4VDNE6Nn5vFwhZkG1fzEDDOaFxq6Q8QO89cBm7AQAAABceyJvcmlnaW4iOiJodHRwczovL2tpbGxlci1tYXJtb3QuYXBwc3BvdC5jb206NDQzIiwiZmVhdHVyZSI6IkJhZGdpbmdWMiIsImV4cGlyeSI6MTU3NjE5MjU1M30=">
   {% if index_js %}<script src="{{ index_js }}"></script>
   <script src="file_handling.js"></script>
   <script src="logging.js"></script>{% endif %}
@@ -10,10 +14,6 @@
   {% if viewport %}<meta name="viewport" content="{{ viewport }}">{% endif %}
   {% if referrer %}<meta name="referrer" content="origin">{% endif %}
   <title>Killer Marmot: {{ short_explanation }}</title>
-  <!-- Origin Trial Token, feature = Badging, origin = https://killer-marmot.appspot.com, expires = 2019-12-04 -->
-  <meta http-equiv="origin-trial" content="ArdlIIOjDvqzGuoUlmOnD61Ep8bE9HFOQ8D9j/wIlQidGmDGmJADnEHeXT0Bo+wLNnOWeFsGO336HonSvn3ZcAQAAABaeyJvcmlnaW4iOiJodHRwczovL2tpbGxlci1tYXJtb3QuYXBwc3BvdC5jb206NDQzIiwiZmVhdHVyZSI6IkJhZGdpbmciLCJleHBpcnkiOjE1NzU0MTc1OTl9">
-  <!-- Origin Trial Token, feature = Badging V2, origin = https://killer-marmot.appspot.com, expires = 2019-12-13 -->
-  <meta http-equiv="origin-trial" content="Auksq5kSoX8H/kF9Z4k/vD340L6qHPFrb9BMLVqQ4ru2cqZ4VDNE6Nn5vFwhZkG1fzEDDOaFxq6Q8QO89cBm7AQAAABceyJvcmlnaW4iOiJodHRwczovL2tpbGxlci1tYXJtb3QuYXBwc3BvdC5jb206NDQzIiwiZmVhdHVyZSI6IkJhZGdpbmdWMiIsImV4cGlyeSI6MTU3NjE5MjU1M30=">
 </head>
 <body>
   <div class="quote">


### PR DESCRIPTION
Works with either the old or new APIs.

Has a V1 and a V2 origin trial token.

Also updates interface to report properly when the badge API isn't available.